### PR TITLE
Add unit representation to the output

### DIFF
--- a/sunshine.el
+++ b/sunshine.el
@@ -234,7 +234,8 @@ FORECAST is the raw forecast data resulting from calling json-read on the
 forecast results."
   (let* ((citylist (cdr (assoc 'city forecast)))
          (city (cdr (assoc 'name citylist)))
-         (country (cdr (assoc 'country citylist))))
+         (country (cdr (assoc 'country citylist)))
+	 (unit (if (equal sunshine-units "imperial") "F" "C")))
     (list
      (cons 'location (concat city ", " country))
      (cons 'days (cl-loop for day across (cdr (assoc 'list forecast)) collect
@@ -242,7 +243,8 @@ forecast results."
                           (cons 'date (format-time-string "%A, %h. %e" (seconds-to-time (cdr (assoc 'dt day)))))
                           (cons 'desc (cdr (assoc 'main (elt (cdr (assoc 'weather day)) 0))))
                           (cons 'icon (cdr (assoc 'icon (elt (cdr (assoc 'weather day)) 0))))
-                          (cons 'temp (cdr (assoc 'temp day)))
+                          (cons 'temp (cl-loop for (key . value) in (cdr (assoc 'temp day))
+					    collect (cons key (format "%s %s" (number-to-string value) unit ))))
                           (cons 'pressure (cdr (assoc 'pressure day)))))))))
 
 (defun sunshine-prepare-window ()
@@ -286,8 +288,8 @@ Pivot it into a dataset like:
              collect (cdr (assoc 'date day)) into dates
              collect (cdr (assoc 'icon day)) into icons
              collect (cdr (assoc 'desc day)) into descs
-             collect (format "High: %s" (number-to-string (cdr (assoc 'max (cdr (assoc 'temp day)))))) into highs
-             collect (format "Low:  %s" (number-to-string (cdr (assoc 'min (cdr (assoc 'temp day)))))) into lows
+             collect (format "High: %s" (cdr (assoc 'max (cdr (assoc 'temp day))))) into highs
+             collect (format "Low:  %s" (cdr (assoc 'min (cdr (assoc 'temp day))))) into lows
              ;; This new list now contains one list for each
              ;; screen line.
              finally (return (list


### PR DESCRIPTION
This was done in regards to the open issue about units (#2). After I started, I saw that you already added the units to the web request, but the proper units(Fahrenheit and Celsius) weren't shown in the UI. So I added them. I thought it might be nice to see them instead of just numbers.

It's a small addition and my first time using elisp, so I'm not sure whether there's a better way to insert the unit, but the solution seemed obvious and I couldn't find how to maybe use the tag from the radio type which already contains C and F.

I'm very thankful for any feedback.
