### PR TITLE
Added support for new Openweather APPID based calls

### DIFF
--- a/sunshine.el
+++ b/sunshine.el
@@ -60,8 +60,8 @@ The location value should be a city/state value like \"New York, NY\""
   :type 'string)
 
 (defcustom sunshine-appid ""
-  "The APPID you got when you registered in Openweather.
-You should get it by loging-in to your account and pasting the API key here"
+  "You can get an APPID by logging into your OpenWeather account.
+You should get it by loging-in to your account and pasting the API key here."
   :group 'sunshine
   :type 'string)
 


### PR DESCRIPTION
It seems Openweather obligates the uses the register and a APPID is provided to each user. Since this APPID is mandatory in the webservice call, it needs to be added. Please check my pull request to add this functionality to sunshine.

Kind Regards
