### PR TITLE
Include a country code in the default location, refs #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An Emacs package for displaying the forecast from OpenWeatherMap.
    `(require 'sunshine)`
 
 3. Configure your location by setting the variable `sunshine-location`.  You can
-   provide a string, like "New York, NY" or a ZIP code, like "90210".  This
+   provide a string, like "New York, NY, US" or a ZIP code, like "90210".  This
    variable is available through the Customize facility.
 
    When specifying a ZIP code, you may receive results from a foreign country.

--- a/sunshine.el
+++ b/sunshine.el
@@ -53,9 +53,9 @@ See `run-hooks'."
   :group 'sunshine
   :type 'hook)
 
-(defcustom sunshine-location "New York, NY"
+(defcustom sunshine-location "New York, NY, US"
   "The default location for which to retrieve weather.
-The location value should be a city/state value like \"New York, NY\""
+The location value should be a city/state value including a country code, like \"New York, NY, US\""
   :group 'sunshine
   :type 'string)
 


### PR DESCRIPTION
As discussed in #12 , the default location setting has a confusing value, as it does not include a country code. I ran into this issue by setting my location to "San Francisco, CA" after looking at the code, although it ought to be "San Francisco, CA, USA". I think this makes the default value better.

The documentation string could probably be updated to mention zip codes etc. as well.