### PR TITLE
Update OpenWeatherMap API to the latest as of 3/6/2020.

### DIFF
--- a/sunshine.el
+++ b/sunshine.el
@@ -152,7 +152,7 @@ The following keys are available in `sunshine-mode':
   "Make a URL for retrieving the weather for LOCATION in UNITS.
 
 Requires your OpenWeatherMap APPID."
-  (concat "http://api.openweathermap.org/data/2.5/forecast/daily?q="
+  (concat "http://api.openweathermap.org/data/2.5/forecast?q="
           (url-encode-url location)
           "&APPID=" appid
           "&mode=json&units="
@@ -274,8 +274,8 @@ forecast results."
                           (cons 'icon (cdr (assoc 'icon (elt (cdr (assoc 'weather day)) 0))))
                           (cons 'temp
                                 (list
-                                 (cons 'min (format "%s %s" (round (cdr (assoc 'min (cdr (assoc 'temp day))))) temp-symbol))
-                                 (cons 'max (format "%s %s" (round (cdr (assoc 'max (cdr (assoc 'temp day))))) temp-symbol))))
+                                 (cons 'min (format "%s %s" (round (cdr (assoc 'temp_min (cdr (assoc 'main day))))) temp-symbol))
+                                 (cons 'max (format "%s %s" (round (cdr (assoc 'temp_max (cdr (assoc 'main day))))) temp-symbol))))
                           (cons 'pressure (cdr (assoc 'pressure (cdr (assoc 'main day)))))))))))
 
 (defun sunshine-prepare-buffer ()


### PR DESCRIPTION
A simple fix to adapt to latest OWM API.
Was getting prompt to enter username and password, and not passing through.